### PR TITLE
fix builds by using the correct babel loader

### DIFF
--- a/config/webpack.defaults.js
+++ b/config/webpack.defaults.js
@@ -22,7 +22,7 @@ module.exports = {
   module: {
     loaders: [{
       test: /\.js$/,
-      loader: 'babel',
+      loader: 'babel-loader',
       include: [path.resolve('src'), path.resolve('server.js')],
       query: {
         passPerPreset: true,


### PR DESCRIPTION
Before:

```
npm run start

> thenib@0.0.0 start /Users/jprins/git/thenib
> react-scripts start

Compiling server build... this will take a while...
Dev server is listening on port 3233 and proxying to app server
Build completed in 0.139s


ERROR in The node API for `babel` has been moved to `babel-core`.
webpack built 78df36dcb9e9688a1baa in 2007ms
chunk    {0} main.js, main.js.map (main) 304 kB [rendered]

ERROR in The node API for `babel` has been moved to `babel-core`.
 @ multi main
webpack: bundle is now VALID.
```

Which would result in thenib server failing to start.