### PR TITLE
Add additional suggested security headers

### DIFF
--- a/lib/defaultHeadersMiddleware.js
+++ b/lib/defaultHeadersMiddleware.js
@@ -10,7 +10,13 @@ module.exports = (req, res, next) => {
   res.set({
     // this should come after express.static otherwise it overrides
     'Cache-Control': 'max-age=300',
+
+    // https://observatory.mozilla.org/ for recommended settings
     'Strict-Transport-Security': 'max-age=15768000; includeSubDomains; preload',
+    'Referrer-Policy': 'no-referrer',
+    'X-Content-Type-Options': 'nosniff',
+    'X-XSS-Protection': '1; mode=block',
+    'X-Frame-Options': 'SAMEORIGIN'
   });
   next();
 };


### PR DESCRIPTION
https://observatory.mozilla.org/analyze.html?host=topic.com was where I noticed we needed these.

https://observatory.mozilla.org/analyze.html?host=theintercept.com for an example of what this would look like afterwards.