### PR TITLE
Support for relay@1/classic in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react": ">=15.3.0",
     "react-addons-test-utils": ">=15.3.0",
     "react-dom": ">=15.3.0",
-    "react-relay": "^0.9.0",
+    "react-relay": ">= 0.9.0",
     "source-map-support": ">=0.4.2"
   },
   "devDependencies": {
@@ -72,7 +72,7 @@
     "react": "^15.3.2",
     "react-addons-test-utils": "^15.3.2",
     "react-dom": "^15.3.2",
-    "react-relay": "0.10.0",
+    "react-relay": "1.1.0",
     "source-map-support": "^0.4.6"
   }
 }

--- a/scripts/utils/__mocks__/react-relay/classic.js
+++ b/scripts/utils/__mocks__/react-relay/classic.js
@@ -1,0 +1,43 @@
+const Relay = jest.genMockFromModule('react-relay/classic');
+
+class MockStore {
+  reset() {
+    this.successResponse = undefined;
+  }
+
+  succeedWith(response) {
+    this.reset();
+    this.successResponse = response;
+  }
+
+  failWith(response) {
+    this.reset();
+    this.failureResponse = response;
+  }
+
+  update(callbacks) {
+    if (this.successResponse) {
+      callbacks.onSuccess(this.successResponse);
+    } else if (this.failureResponse) {
+      callbacks.onFailure(this.failureResponse);
+    }
+    this.reset();
+  }
+
+  commitUpdate(mutation, callbacks) {
+    return this.update(callbacks);
+  }
+
+  applyUpdate(mutation, callbacks) {
+    return this.update(callbacks);
+  }
+}
+
+module.exports = {
+  QL: Relay.QL,
+  Mutation: Relay.Mutation,
+  Route: Relay.Route,
+  RootContainer: () => null,
+  createContainer: (component) => component,
+  Store: new MockStore(),
+};

--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -4,6 +4,7 @@ module.exports = () => ({
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': path.resolve(__dirname, '__mocks__/file.js'),
     '\\.(css)$': require.resolve('identity-obj-proxy'),
+    'react-relay/classic': path.resolve(__dirname, '__mocks__/react-relay/classic.js'),
     'react-relay': path.resolve(__dirname, '__mocks__/react-relay.js'),
   },
   transform: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -946,12 +946,19 @@ babel-relay-plugin@0.10.0:
   dependencies:
     graphql "0.8.2"
 
-babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.6.1, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
+babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.18.0.tgz#0f4177ffd98492ef13b9f823e9994a02584c9078"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.9.5"
+
+babel-runtime@^6.23.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.25.0.tgz#33b98eaa5d482bb01a8d1aa6b437ad2b01aec41c"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
 
 babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.8.0:
   version "6.16.0"
@@ -5213,7 +5220,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4:
+prop-types@^15.5.4, prop-types@^15.5.8:
   version "15.5.8"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
@@ -5301,13 +5308,15 @@ react-dom@^15.3.2:
   version "15.3.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.3.2.tgz#c46b0aa5380d7b838e7a59c4a7beff2ed315531f"
 
-react-relay@0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-0.10.0.tgz#4b19c4450e0140b9f04fd6fe96d8f451f0804078"
+react-relay@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-1.1.0.tgz#56cd76885a886d93dd052efebbc0af5b6ceea998"
   dependencies:
-    babel-runtime "^6.6.1"
+    babel-runtime "^6.23.0"
     fbjs "^0.8.1"
+    prop-types "^15.5.8"
     react-static-container "^1.0.1"
+    relay-runtime "1.1.0"
 
 react-static-container@^1.0.1:
   version "1.0.1"
@@ -5432,6 +5441,10 @@ regenerate@^1.2.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.1.tgz#0300203a5d2fdcf89116dce84275d011f5903f33"
 
+regenerator-runtime@^0.10.0:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
 regenerator-runtime@^0.9.5:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
@@ -5468,6 +5481,13 @@ regjsparser@^0.1.4:
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.1.5.tgz#7ee8f84dc6fa792d3fd0ae228d24bd949ead205c"
   dependencies:
     jsesc "~0.5.0"
+
+relay-runtime@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-1.1.0.tgz#2441a97c18e3c9035960cad48414a95844623b69"
+  dependencies:
+    babel-runtime "^6.23.0"
+    fbjs "^0.8.1"
 
 repeat-element@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This adds a mock for `react-relay/classic` so we can support projects at relay < 1, as well as relay >= 1 with `/classic`. This doesn't add mocks for "relay modern"