### PR TITLE
FLP-2161: Add upload ability to react scripts

### DIFF
--- a/bin/react-scripts.js
+++ b/bin/react-scripts.js
@@ -8,6 +8,7 @@ const args = process.argv.slice(3);
 switch (script) {
   case 'build':
   case 'start':
+  case 'upload':
   case 'test': {
     const result = spawn.sync(
       'node',

--- a/config/webpack.client.prod.js
+++ b/config/webpack.client.prod.js
@@ -25,6 +25,7 @@ const config = Object.assign({}, defaults, {
   }),
   plugins: defaults.plugins.concat([
     new ManifestPlugin({ fileName: 'manifest.json' }),
+    new ManifestPlugin({ fileName: `manifest.${Date.now()}.json` }),
     new ExtractTextPlugin('[contenthash].css'),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': '"production"',

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "autoprefixer": "^6.3.7",
+    "aws-sdk": "^2.94.0",
     "babel": "^6.5.2",
     "babel-core": "^6.11.4",
     "babel-jest": "^19.0.0",

--- a/scripts/upload.js
+++ b/scripts/upload.js
@@ -6,38 +6,14 @@ const path = require('path');
 const fs = require('fs');
 
 let s3 = new AWS.S3({apiVersion: '2006-03-01'});
-let env = process.env.FLM_ENV
-let uploadParams = {Bucket: '', Key: '', Body: ''};
+let bucket = process.env.ASSETS_S3_BUCKET;
+let uploadParams = {Bucket: bucket, Key: '', Body: ''};
 let project_name = require(path.join(process.cwd(), 'package.json')).name;
 let base_dir = './build/assets';
-console.log(process.cwd(), project_name);
 
-// We could turn on uploading for everyone with this.
-// if (!env) {
-//   env = "local";
-//   console.log("FLM_ENV is empty, setting to 'local'.");
-// }
-
-switch (env) {
-  case "development":
-    uploadParams.Bucket = "assets.dev.flmcloud.net";
-    break;
-  case "staging":
-    uploadParams.Bucket = "assets.staging.flmcloud.net";
-    break;
-  case "local":
-    uploadParams.Bucket = "assets.test.flmcloud.net";
-    break;
-  case "test":
-    uploadParams.Bucket = "assets.test.flmcloud.net";
-    break;
-  case "production":
-    uploadParams.Bucket = "assets.prod.flmcloud.net";
-    break;
-  default:
-    console.error("FLM_ENV is empty. Exiting.");
-    process.exit(0)
-    break;
+if (!bucket) {
+  console.error("ASSETS_S3_BUCKET is empty. Exiting.");
+  process.exit(1)
 }
 
 fs.readdir(base_dir, (err, files) => {

--- a/scripts/upload.js
+++ b/scripts/upload.js
@@ -1,0 +1,57 @@
+'use strict';
+process.env.NODE_ENV = 'production';
+
+const AWS = require('aws-sdk');
+const path = require('path');
+const fs = require('fs');
+
+let s3 = new AWS.S3({apiVersion: '2006-03-01'});
+let env = process.env.FLM_ENV
+let uploadParams = {Bucket: '', Key: '', Body: ''};
+let project_name = require(path.join(process.cwd(), 'package.json')).name;
+let base_dir = './build/assets';
+console.log(process.cwd(), project_name);
+
+if (!env) {
+  env = "local";
+  console.log("FLM_ENV is empty, setting to 'local'.");
+}
+
+switch (env) {
+  case "development":
+    uploadParams.Bucket = "assets.dev.flmcloud.net";
+    break;
+  case "staging":
+    uploadParams.Bucket = "assets.staging.flmcloud.net";
+    break;
+  case "local":
+    uploadParams.Bucket = "assets.test.flmcloud.net";
+    break;
+  case "test":
+    uploadParams.Bucket = "assets.test.flmcloud.net";
+    break;
+  case "production":
+    uploadParams.Bucket = "assets.prod.flmcloud.net";
+    break;
+  default:
+    console.error("FLM_ENV is empty. Exiting.");
+    break;
+}
+
+fs.readdir(base_dir, (err, files) => {
+  files.forEach(file => {
+    let fileStream = fs.createReadStream(path.join(base_dir, file));
+    fileStream.on('error', function(err) {
+      console.log('File Error', err);
+    });
+    uploadParams.Body = fileStream;
+    uploadParams.Key = `${project_name}/${file}`;
+    s3.upload(uploadParams, function (err, data) {
+      if (err) {
+        console.log("Error", err);
+      } if (data) {
+        console.log("Upload Success", data.Location);
+      }
+    });
+  });
+})

--- a/scripts/upload.js
+++ b/scripts/upload.js
@@ -12,10 +12,11 @@ let project_name = require(path.join(process.cwd(), 'package.json')).name;
 let base_dir = './build/assets';
 console.log(process.cwd(), project_name);
 
-if (!env) {
-  env = "local";
-  console.log("FLM_ENV is empty, setting to 'local'.");
-}
+// We could turn on uploading for everyone with this.
+// if (!env) {
+//   env = "local";
+//   console.log("FLM_ENV is empty, setting to 'local'.");
+// }
 
 switch (env) {
   case "development":
@@ -35,6 +36,7 @@ switch (env) {
     break;
   default:
     console.error("FLM_ENV is empty. Exiting.");
+    process.exit(0)
     break;
 }
 

--- a/scripts/upload.js
+++ b/scripts/upload.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 let s3 = new AWS.S3({apiVersion: '2006-03-01'});
 let bucket = process.env.ASSETS_S3_BUCKET;
 let uploadParams = {Bucket: bucket, Key: '', Body: ''};
-let project_name = require(path.join(process.cwd(), 'package.json')).name;
+let projectName = require(path.join(process.cwd(), 'package.json')).name;
 let base_dir = './build/assets';
 
 if (!bucket) {
@@ -23,7 +23,7 @@ fs.readdir(base_dir, (err, files) => {
       console.log('File Error', err);
     });
     uploadParams.Body = fileStream;
-    uploadParams.Key = `${project_name}/${file}`;
+    uploadParams.Key = `${projectName}/${file}`;
     s3.upload(uploadParams, function (err, data) {
       if (err) {
         console.log("Error", err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,6 +258,21 @@ autoprefixer@^6.3.1, autoprefixer@^6.3.7:
     postcss "^5.2.5"
     postcss-value-parser "^3.2.3"
 
+aws-sdk@^2.94.0:
+  version "2.94.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.94.0.tgz#7043de3ef8c24cb6ab4bf235f08d87d84173e174"
+  dependencies:
+    buffer "4.9.1"
+    crypto-browserify "1.0.9"
+    events "^1.1.1"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.0.1"
+    xml2js "0.4.17"
+    xmlbuilder "4.2.1"
+
 aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
@@ -1163,7 +1178,7 @@ buffer-to-vinyl@^1.0.0:
     uuid "^2.0.1"
     vinyl "^1.0.0"
 
-buffer@^4.9.0:
+buffer@4.9.1, buffer@^4.9.0:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   dependencies:
@@ -1514,6 +1529,10 @@ cryptiles@2.x.x:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
     boom "2.x.x"
+
+crypto-browserify@1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-1.0.9.tgz#cc5449685dfb85eb11c9828acc7cb87ab5bbfcc0"
 
 crypto-browserify@~3.2.6:
   version "3.2.8"
@@ -2225,7 +2244,7 @@ eventemitter3@1.x.x:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
 
-events@^1.0.0:
+events@^1.0.0, events@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
 
@@ -3737,6 +3756,10 @@ jest@^19.0.2:
   resolved "https://registry.yarnpkg.com/jest/-/jest-19.0.2.tgz#b794faaf8ff461e7388f28beef559a54f20b2c10"
   dependencies:
     jest-cli "^19.0.2"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
 
 jodid25519@^1.0.0:
   version "1.0.2"
@@ -5651,9 +5674,13 @@ sane@~1.5.0:
     walker "~1.0.5"
     watch "~0.10.0"
 
-sax@^1.1.4, sax@^1.2.1, sax@~1.2.1:
+sax@1.2.1, sax@^1.1.4, sax@^1.2.1, sax@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
 seek-bzip@^1.0.3:
   version "1.0.5"
@@ -6253,7 +6280,7 @@ url-regex@^3.0.0:
   dependencies:
     ip-regex "^1.0.1"
 
-url@~0.10.1:
+url@0.10.3, url@~0.10.1:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
   dependencies:
@@ -6280,13 +6307,13 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
+uuid@3.0.1, uuid@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+
 uuid@^2.0.1, uuid@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
-
-uuid@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
 vali-date@^1.0.0:
   version "1.0.0"
@@ -6574,6 +6601,19 @@ write@^0.2.1:
 "xml-name-validator@>= 2.0.1 < 3.0.0", xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+xml2js@0.4.17:
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.17.tgz#17be93eaae3f3b779359c795b419705a8817e868"
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "^4.1.0"
+
+xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
+  dependencies:
+    lodash "^4.0.0"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0:
   version "4.0.1"


### PR DESCRIPTION
I tested this by changing package.json in falcon:

```
$ git diff package.json
diff --git a/package.json b/package.json
index 9d9976cbbaec..473c16b3e02d 100644
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start-production": "NODE_ENV=production node ./build/server.js",
     "update-schema": "node ./scripts/updateSchema.js",
     "test": "TZ=utc react-scripts test",
-    "build": "react-scripts build"
+    "build": "react-scripts build",
+    "upload": "react-scripts upload"
   },
   "author": "First Look Media",
   "license": "ISC",
@@ -56,7 +57,7 @@
     "react-router": "2.5.2",
     "react-router-relay": "0.13.3",
     "react-router-scroll": "^0.4.1",
-    "react-scripts": "git+ssh://git@github.com/firstlookmedia/react-scripts.git",
+    "react-scripts": "git+ssh://git@github.com/firstlookmedia/react-scripts.git#nw/s3",
     "react-textarea-autosize": "4.0.3",
     "react-virtualized": "^9.7.3",
     "recompose": "0.23.4",
```

And then running `git co -- yarn.lock; yarn install; yarn run build; yarn run upload`