### PR TITLE
Add a brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,3 @@
+# https://robots.thoughtbot.com/brewfile-a-gemfile-but-for-homebrew
+
+brew 'watchman'

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Builds the production assets to the `build` folder.
 
 #### `npm test`
 
+You will need `watchman` to use `npm test` without `CI=true`. To install on OSX `brew bundle` in this directory.
+
 Runs mocha tests. `react-scripts` will look for any file named `__spec.js`.
 
 `react-scripts` adds chai assertion helpers for


### PR DESCRIPTION
I ran into the issue of not having watchman installed:

```
$ npm test

[redacted]
> react-scripts test

2017-09-19 18:03 node[22481] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-22)
2017-09-19 18:03 node[22481] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-22)
2017-09-19 18:03 node[22481] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-22)
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: Error watching file for changes: EMFILE
    at exports._errnoException (util.js:1020:11)
    at FSEvent.FSWatcher._handle.onchange (fs.js:1420:11)
npm ERR! Test failed.  See above for more details.
```

The fix is to either run `CI=true npm test` or `brew install watchman` and then `npm test`. This puts watchman as a thing so you can just run `brew bundle` in this repo to install it (and any other future deps).