### PR TITLE
Add mimetypes to uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jsdom": "^9.4.1",
     "json-loader": "^0.5.4",
     "loader-utils": "^0.2.16",
+    "mime": "^2.0.3",
     "postcss-calc": "^5.3.1",
     "postcss-loader": "^0.9.1",
     "precss": "^1.4.0",
@@ -58,9 +59,9 @@
     "babel-runtime": ">=6.11.6",
     "enzyme": ">=2.7.1",
     "react": ">=15.3.0",
-    "react-test-renderer": ">=15.3.0",
     "react-dom": ">=15.3.0",
     "react-relay": ">= 0.9.0",
+    "react-test-renderer": ">=15.3.0",
     "source-map-support": ">=0.4.2"
   },
   "devDependencies": {

--- a/scripts/upload.js
+++ b/scripts/upload.js
@@ -4,6 +4,7 @@ process.env.NODE_ENV = 'production';
 const AWS = require('aws-sdk');
 const path = require('path');
 const fs = require('fs');
+const mime = require('mime');
 
 let s3 = new AWS.S3({apiVersion: '2006-03-01'});
 let bucket = process.env.ASSETS_S3_BUCKET;
@@ -24,6 +25,11 @@ fs.readdir(base_dir, (err, files) => {
     });
     uploadParams.Body = fileStream;
     uploadParams.Key = `${projectName}/assets/${file}`;
+
+    let type = mime.getType(file);
+    if (type) {
+      uploadParams.ContentType = type;
+    }
     s3.upload(uploadParams, function (err, data) {
       if (err) {
         console.log("Error", err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4347,6 +4347,10 @@ mime@1.3.4, mime@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
+mime@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.0.3.tgz#4353337854747c48ea498330dc034f9f4bbbcc0b"
+
 "minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"


### PR DESCRIPTION
As a follow on to https://github.com/firstlookmedia/react-scripts/pull/25, apparently the AWS library isn't dealing with mimetypes correctly. This is fine for most things, but chrome doesn't like css that doesn't have the right mime-type.