### PR TITLE
Manifest: omits main.css in development mode, since it doesn't exist

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -14,7 +14,6 @@ const isProd = process.env.NODE_ENV === 'production';
 // manifest defaults for development
 const manifest = {
   'main.js': '/assets/main.js',
-  'main.css': '/assets/main.css',
 };
 
 if (isProd) {

--- a/template/server.js
+++ b/template/server.js
@@ -32,6 +32,14 @@ app.use(express.static('public'));
 app.use(defaultHeadersMiddleware);
 app.use('/graphql', graphqlProxyMiddleware(GRAPHQL_URL));
 
+const stylesheetTag = (href) => {
+  if (!href) {
+    return '';
+  }
+
+  return `<link href="${href}" type="text/css" rel="stylesheet">`
+};
+
 app.get('*', async (req, res) => {
   const fetcher = new ServerFetcher(GRAPHQL_URL);
 
@@ -54,7 +62,7 @@ app.get('*', async (req, res) => {
     <meta charset="utf-8">
     <title>Hello world</title>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <link href="${manifest['main.css']}" type="text/css" rel="stylesheet">
+    ${stylesheetTag(manifest['main.css'])}
   </head>
   <body>
     <div id="root">${ReactDOMServer.renderToString(element)}</div>


### PR DESCRIPTION
Running a react-scripts app in development right now leads to a 404 on each render since Webpack doesn't generate a `main.css` file in development mode (the CSS is injected via JS instead)